### PR TITLE
key-store: fix getVar() missing positional argument

### DIFF
--- a/recipes-support/key-store/key-store_0.1.bb
+++ b/recipes-support/key-store/key-store_0.1.bb
@@ -41,8 +41,8 @@ python () {
 
     pn = d.getVar('PN', True) + '-rpm-pubkey'
     d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-*'))
-    d.setVar('CONFFILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + 'RPM-GPG-KEY-*'))
+    d.setVar('FILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-*', True))
+    d.setVar('CONFFILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + 'RPM-GPG-KEY-*', True))
     d.appendVar('RDEPENDS_' + pn, ' rpm')
 }
 


### PR DESCRIPTION
TypeError: getVar() missing 1 required positional argument: 'expand'

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>