### PR TITLE
user-key-store.bbclass: don't run check_deploy_keys in parallel

### DIFF
--- a/classes/user-key-store.bbclass
+++ b/classes/user-key-store.bbclass
@@ -442,3 +442,5 @@ python check_deploy_keys() {
 
         deploy_keys(_, d)
 }
+
+check_deploy_keys[lockfiles] = "${TMPDIR}/check_deploy_keys.lock"


### PR DESCRIPTION
Set lockfile for task check_deploy_keys() to avoid the race error from
'cp -af':

  cp: cannot create regular file '.../tmp/deploy/images/intel-x86-64/
    sample-keys/uefi_sb_keys/DBX/DBX.key': File exists

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>